### PR TITLE
Fix version conflicts caused by PR#60

### DIFF
--- a/src/NXPorts/NXPorts.csproj
+++ b/src/NXPorts/NXPorts.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSbuildProjectName).nuspec</NuspecFile>
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NXPorts.Attributes\NXPorts.Attributes.csproj" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
     <PackageReference Include="dnLib" Version="3.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.Build.Framework from 15.9.20 to 16.10.0. [(PR#60)](https://github.com/MeikTranel/NXPorts/pull/60).
Hope this fix can help you.

Best regards,
sucrose